### PR TITLE
Fix issue #4

### DIFF
--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function fallback (cb) {
 		  exec("grep \"^`whoami`:\" /etc/passwd | awk -F: '{print $5}'", function(err,stdout){
 		        fullname = stdout.trim().replace(/,.*/, '');
 			fullname = fullname.replace(/(?:\r\n|\r|\n)/g, '');
-			stdout.print(fullname);
+			process.stdout.write(fullname);
 			if (err || !fullname || fullname.length == 0) {
 				exec('git config --global user.name', function (err, stdout) {
 					if (err) {

--- a/index.js
+++ b/index.js
@@ -88,7 +88,7 @@ function fallback (cb) {
 		  exec("grep \"^`whoami`:\" /etc/passwd | awk -F: '{print $5}'", function(err,stdout){
 		        fullname = stdout.trim().replace(/,.*/, '');
 			fullname = fullname.replace(/(?:\r\n|\r|\n)/g, '');
-			if (err || !fullname) {
+			if (err || !fullname || fullname.length == 0) {
 				exec('git config --global user.name', function (err, stdout) {
 					if (err) {
 						cb();

--- a/index.js
+++ b/index.js
@@ -88,6 +88,7 @@ function fallback (cb) {
 		  exec("grep \"^`whoami`:\" /etc/passwd | awk -F: '{print $5}'", function(err,stdout){
 		        fullname = stdout.trim().replace(/,.*/, '');
 			fullname = fullname.replace(/(?:\r\n|\r|\n)/g, '');
+			stdout.print(fullname);
 			if (err || !fullname || fullname.length == 0) {
 				exec('git config --global user.name', function (err, stdout) {
 					if (err) {

--- a/index.js
+++ b/index.js
@@ -81,20 +81,25 @@ function fallback (cb) {
 	}
 
 	exec('getent passwd $(whoami)', function (err, stdout) {
-		fullname = stdout.trim().split(':')[4].replace(/,.*/, '');
-
-		if (err || !fullname) {
-			exec('git config --global user.name', function (err, stdout) {
-				if (err) {
-					cb();
-					return;
-				}
-
-				fullname = stdout.trim();
-
-				cb(null, fullname);
-			});
-			return;
+		if(stdout.trim().length != 0){
+		   fullname = stdout.trim().split(':')[4].replace(/,.*/, '');
+		} else {
+		  exec('grep "^`whoami`:" /etc/passwd | awk -F: ''{print $5}''', function(err,stdout){
+		  	fullname = stdout.trim();
+			if (err || !fullname) {
+				exec('git config --global user.name', function (err, stdout) {
+					if (err) {
+						cb();
+						return;
+					}
+	
+					fullname = stdout.trim();
+	
+					cb(null, fullname);
+				});
+				return;
+			}
+		   });
 		}
 
 		cb(null, fullname);

--- a/index.js
+++ b/index.js
@@ -83,9 +83,11 @@ function fallback (cb) {
 	exec('getent passwd $(whoami)', function (err, stdout) {
 		if(stdout.trim().length != 0){
 		   fullname = stdout.trim().split(':')[4].replace(/,.*/, '');
+		   cb(null, fullname);
 		} else {
-		  exec('grep "^`whoami`:" /etc/passwd | awk -F: ''{print $5}''', function(err,stdout){
-		  	fullname = stdout.trim();
+		  exec("grep \"^`whoami`:\" /etc/passwd | awk -F: '{print $5}'", function(err,stdout){
+		        fullname = stdout.trim().replace(/,.*/, '');
+			fullname = fullname.replace(/(?:\r\n|\r|\n)/g, '');
 			if (err || !fullname) {
 				exec('git config --global user.name', function (err, stdout) {
 					if (err) {
@@ -96,12 +98,14 @@ function fallback (cb) {
 					fullname = stdout.trim();
 	
 					cb(null, fullname);
+					return;
 				});
 				return;
 			}
+			cb(null, fullname);
+			return;
 		   });
 		}
 
-		cb(null, fullname);
 	});
 }


### PR DESCRIPTION
Better handle fallback. Added another command as alternative as getent passwd $(whoami) is not working;
I work in a Governor IT Company in Brazil, and me and coworks here were getting throuble using yeoman because of this bug.
An alternative i applied before was using .npmrc init.author.name, because this is tried before the error
node_modules/fullname/index.js:84
fullname = stdout.trim().split(':')[4].replace(/,.*/, '');
^
TypeError: Cannot read property 'replace' of undefined