### PR TITLE
Use `passwd-user` as initial fallback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,4 @@ language: node_js
 node_js:
   - '5'
   - '4'
-  - '0.12'
-  - '0.10'
 before_script: git config --global user.name 'Unicorn Cake'

--- a/index.js
+++ b/index.js
@@ -1,13 +1,12 @@
 'use strict';
-var npmconf = require('npmconf');
-var pify = require('pify');
-var Promise = require('pinkie-promise');
-var execa = require('execa');
-var passwdUser = require('passwd-user');
-var fullname;
-var first = true;
+const npmconf = require('npmconf');
+const pify = require('pify');
+const execa = require('execa');
+const passwdUser = require('passwd-user');
+let fullname;
+let first = true;
 
-module.exports = function () {
+module.exports = () => {
 	if (!first) {
 		return Promise.resolve(fullname);
 	}
@@ -18,77 +17,63 @@ module.exports = function () {
 		return Promise.resolve(fullname);
 	}
 
-	return pify(npmconf.load, Promise)().then(function (conf) {
+	return pify(npmconf.load)().then(conf => {
 		fullname = conf.get('init.author.name');
 
 		if (!fullname) {
-			return fallback();
+			return fallback().then(() => fullname);
 		}
 
 		return fullname;
-	}).catch(fallback).catch(function () {});
+	}).catch(fallback).then(() => fullname).catch(() => {});
 };
 
 function fallback() {
 	if (process.platform === 'darwin') {
 		return passwdUser(process.getuid())
-			.then(function (user) {
-				return user.fullname;
-			})
-			.catch(function () {
+			.then(user => fullname = user.fullname)
+			.catch(() => {
 				return execa('osascript', ['-e', '"long user name of (system info)"'])
-					.then(function (res) {
-						fullname = res.stdout;
-
-						return fullname;
-					});
+					.then(res => fullname = res.stdout);
 			});
 	}
 
 	if (process.platform === 'win32') {
 		// try git first since fullname is usually not set by default in the system on Windows 7+
 		return execa('git', ['config', '--global', 'user.name'])
-			.then(function (res) {
+			.then(res => {
 				fullname = res.stdout;
 
 				if (!fullname) {
 					throw new Error();
 				}
-
-				return fullname;
 			})
-			.catch(function () {
+			.catch(() => {
 				return execa('wmic', ['useraccount', 'where', 'name="%username%"', 'get', 'fullname'])
-					.then(function (res) {
-						fullname = res.stdout.replace('FullName', '');
-
-						return fullname;
-					});
+					.then(res => fullname = res.stdout.replace('FullName', ''));
 			});
 	}
 
 	return passwdUser(process.getuid())
-		.then(function (user) {
-			return user.fullname;
+		.then(user => {
+			fullname = user.fullname;
+
+			if (!fullname) {
+				throw new Error();
+			}
 		})
-		.catch(function () {
-			return execa('getent', ['passwd', '$(whoami)'])
-				.then(function (res) {
+		.catch(() => {
+			return execa.shell('getent passwd $(whoami)')
+				.then(res => {
 					fullname = (res.stdout.split(':')[4] || '').replace(/,.*/, '');
 
 					if (!fullname) {
 						throw new Error();
 					}
-
-					return fullname;
 				});
 		})
-		.catch(function () {
+		.catch(() => {
 			return execa('git', ['config', '--global', 'user.name'])
-				.then(function (res) {
-					fullname = res.stdout;
-
-					return fullname;
-				});
+				.then(res => fullname = res.stdout);
 		});
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "url": "sindresorhus.com"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "xo && ava"
@@ -37,11 +37,13 @@
     "execa": "^0.2.1",
     "npmconf": "^2.1.1",
     "passwd-user": "^2.0.0",
-    "pify": "^2.2.0",
-    "pinkie-promise": "^2.0.0"
+    "pify": "^2.2.0"
   },
   "devDependencies": {
     "ava": "*",
     "xo": "*"
+  },
+  "xo": {
+    "esnext": true
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "uid"
   ],
   "dependencies": {
+    "execa": "^0.2.1",
     "npmconf": "^2.1.1",
     "pify": "^2.2.0",
     "pinkie-promise": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   "dependencies": {
     "execa": "^0.2.1",
     "npmconf": "^2.1.1",
+    "passwd-user": "^2.0.0",
     "pify": "^2.2.0",
     "pinkie-promise": "^2.0.0"
   },


### PR DESCRIPTION
Requires https://github.com/sindresorhus/passwd-user/pull/5 to be merged and released first to make use of it's promise API. Also snuck in a change to use `execa` instead of `childProcess.exec`.