### PR TITLE
Memoize based on environment variables

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,14 +5,21 @@ const execa = require('execa');
 const passwdUser = require('passwd-user');
 const pAny = require('p-any');
 const pTry = require('p-try');
+const filterObj = require('filter-obj');
+
+const envVars = [
+	'GIT_AUTHOR_NAME',
+	'GIT_COMMITTER_NAME',
+	'HGUSER', // Mercurial
+	'C9_USER' // Cloud9
+];
 
 function checkEnv() {
 	return pTry(() => {
 		const env = process.env;
-		const fullname = env.GIT_AUTHOR_NAME ||
-			env.GIT_COMMITTER_NAME ||
-			env.HGUSER || // Mercurial
-			env.C9_USER; // Cloud9
+
+		const varName = envVars.find(x => env[x]);
+		const fullname = varName && env[varName];
 
 		return fullname || Promise.reject();
 	});
@@ -75,4 +82,8 @@ function getFullName() {
 		.catch(() => {});
 }
 
-module.exports = mem(getFullName);
+module.exports = mem(getFullName, {
+	cacheKey() {
+		return JSON.stringify(filterObj(process.env, envVars));
+	}
+});

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   ],
   "dependencies": {
     "execa": "^0.4.0",
+    "filter-obj": "^1.1.0",
     "mem": "^1.1.0",
     "p-any": "^1.0.0",
     "p-try": "^1.0.0",

--- a/test.js
+++ b/test.js
@@ -36,6 +36,22 @@ test('should get fullname from env var', async t => {
 	t.is(fullname, 'TEST-ENV-FULL-NAME');
 });
 
+test('respects changed env vars', async t => {
+	const m = requireUncached('./');
+	mem.clear(m);
+
+	process.env.GIT_AUTHOR_NAME = 'NAME-1';
+	const fullname1 = await m();
+	process.env.GIT_AUTHOR_NAME = 'NAME-2';
+	const fullname2 = await m();
+
+	t.is(typeof fullname1, 'string');
+	t.is(fullname1, 'NAME-1');
+	t.is(typeof fullname2, 'string');
+	t.is(fullname2, 'NAME-2');
+	t.not(fullname1, fullname2);
+});
+
 test('should get value from init-author-name', async t => {
 	mock('rc', () => ({
 		'init-author-name': 'TEST-INIT-AUTHOR-FULL-NAME'


### PR DESCRIPTION
Fix #13 by keying the mem cache with the value of environment variables we pay attention to.

Doing this allows changes in the environment to be reflected immediately in the return value, while still aggressively caching the more expensive I/O bound lookup strategies.