### PR TITLE
Fix: When changing username in Linux the fullname still return

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,8 +10,7 @@ const environmentVariables = [
 	'GIT_COMMITTER_NAME',
 	'HGUSER', // Mercurial
 	'C9_USER', // Cloud9
-	//https://www.unix.com/shell-programming-and-scripting/152400-unix-user-logname-environment-variables.html (about $USER and $LOGNAME)
-	//Both is same but include both for precaution if some linux just only set one of these enviroment variable
+        //Both is same but include both for precaution if some linux just only set one of these enviroment variable
 	'LOGNAME', //Original System V Unix
 	'USER' //Introduced in BSD
 ];

--- a/index.js
+++ b/index.js
@@ -10,9 +10,8 @@ const environmentVariables = [
 	'GIT_COMMITTER_NAME',
 	'HGUSER', // Mercurial
 	'C9_USER', // Cloud9
-        //Both is same but include both for precaution if some linux just only set one of these enviroment variable
-	'LOGNAME', //Original System V Unix
-	'USER' //Introduced in BSD
+	'LOGNAME',
+	'USER'
 ];
 
 /* eslint-disable unicorn/error-message */

--- a/index.js
+++ b/index.js
@@ -9,7 +9,11 @@ const environmentVariables = [
 	'GIT_AUTHOR_NAME',
 	'GIT_COMMITTER_NAME',
 	'HGUSER', // Mercurial
-	'C9_USER' // Cloud9
+	'C9_USER', // Cloud9
+	//https://www.unix.com/shell-programming-and-scripting/152400-unix-user-logname-environment-variables.html (about $USER and $LOGNAME)
+	//Both is same but include both for precaution if some linux just only set one of these enviroment variable
+	'LOGNAME', //Original System V Unix
+	'USER' //Introduced in BSD
 ];
 
 /* eslint-disable unicorn/error-message */


### PR DESCRIPTION
original username

Found this when i change username and run yo (it print 'Allo {the old username}' instead new one)
Add 'LOGNAME' and 'USER' to the 'enviromentVariables' just that i did i cant really code in javascript and i tested it on my linux